### PR TITLE
Use Chrome's built-in favicon cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lodash": "^3.10.1",
     "object-assign": "^4.0.1",
     "oneref": "^0.1.3",
-    "react": "^0.14.6"
+    "react": "^0.14.6",
+    "react-dom": "^0.14.6"
   },
   "devDependencies": {
     "babel": "^6.3.26",

--- a/src/js/components/TabItem.js
+++ b/src/js/components/TabItem.js
@@ -85,7 +85,7 @@ const TabItem = React.createClass({
       tabCheckItem = <div style={Styles.headerButton} />;
     }
 
-    var fiSrc = tab.favIconUrl ? tab.favIconUrl : '';
+    var fiSrc = 'chrome://favicon/size/16/' + tab.url;
 
     // Skip the chrome FAVICONs; they just throw when accessed.
     if (fiSrc.indexOf('chrome://theme/') === 0) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,7 +13,8 @@
     "persistent": true
   },  
   "permissions": [
-    "downloads", "storage", "tabs", "bookmarks"
+    "downloads", "storage", "tabs", "bookmarks",
+    "chrome://favicon/*"
   ],
   "icons": {
     "16": "images/glyphicons_154_more_windows.png",


### PR DESCRIPTION
Prevent excessive amount of favicon requests, if you have a lot of tabs. 

Also, this fixes a number of other issues with favicons:
- Unopened tabs/pages favicons now work (resolves #21)
- Chrome url extension pages favicon now work
- More..