### PR TITLE
Dedup google docs

### DIFF
--- a/src/ts/components/PreferencesModal.tsx
+++ b/src/ts/components/PreferencesModal.tsx
@@ -109,6 +109,14 @@ const PreferencesModal: React.FC<PreferencesModalProps> = ({
         setPrefs(nextPrefs);
     };
 
+    const handleDedupeGoogleDocsChange = (
+        e: React.ChangeEvent<HTMLInputElement>
+    ) => {
+        const oldPrefs = prefs;
+        const nextPrefs = oldPrefs.set('dedupeGoogleDocs', !oldPrefs.dedupeGoogleDocs);
+        setPrefs(nextPrefs);
+    };
+
     const handleRevertOnOpenChange = (
         e: React.ChangeEvent<HTMLInputElement>,
     ) => {
@@ -247,6 +255,23 @@ const PreferencesModal: React.FC<PreferencesModalProps> = ({
                                 />
                                 <label className={checkLabelStyle}>
                                     Automatically close duplicate tabs
+                                </label>
+                            </div>
+                            <div
+                                className={cx(
+                                    'checkbox',
+                                    rightCol,
+                                    prefsLabeledCheckbox,
+                                )}
+                            >
+                                <input
+                                    type="checkbox"
+                                    className={prefsCheckbox}
+                                    checked={prefs.dedupeGoogleDocs}
+                                    onChange={(e) => handleDedupeGoogleDocsChange(e)}
+                                />
+                                <label className={checkLabelStyle}>
+                                    Automatically close duplicate Google Docs (requires "Automatically close duplicate tabs")
                                 </label>
                             </div>
                             <div

--- a/src/ts/preferences.ts
+++ b/src/ts/preferences.ts
@@ -17,6 +17,7 @@ export const USER_PREFS_KEY = 'UserPreferences';
 interface PreferencesProps {
     popoutOnStart: boolean; // show popout on startup?
     dedupeTabs: boolean; // close tab if URL matches existing tab
+    dedupeGoogleDocs: boolean; // deduplicate google docs regardless of parameters etc.
     revertOnOpen: boolean; // revert to anchor tabs when opening saved window
     theme: string;
     layout: string;
@@ -26,6 +27,7 @@ interface PreferencesProps {
 const defaultPreferencesProps: PreferencesProps = {
     popoutOnStart: false,
     dedupeTabs: false,
+    dedupeGoogleDocs: false,
     revertOnOpen: true,
     theme: 'light',
     layout: 'normal',

--- a/src/ts/state.ts
+++ b/src/ts/state.ts
@@ -330,6 +330,11 @@ const dedupeTab = async (
         pairs.map(([a, b]) => [a.toJS(), b.toJS()]);
 
     try {
+        // Check if general tab deduplication is enabled
+        if (!st.preferences.dedupeTabs) {
+            return; // Exit early if general deduplication is disabled
+        }
+
         const url = changeInfo.url;
 
         // TODO: We should really look at pendingUrl, to try and dedupe tabs earlier...

--- a/src/ts/state.ts
+++ b/src/ts/state.ts
@@ -380,17 +380,15 @@ const dedupeTab = async (
                     tabId,
                 );
                 const tabWindow = st.getTabWindowByChromeId(tab.windowId);
-                const tabClosedSt = await actions.closeTab(
-                    tabWindow!,
-                    tabId,
-                    stateRef,
-                );
-                actions.activateOrRestoreTab(
-                    origTabWindow,
-                    origTab,
-                    0,
-                    stateRef,
-                );
+                if (tabWindow) {
+                    await actions.closeTab(tabWindow, tabId, stateRef);
+                    await actions.activateOrRestoreTab(
+                        origTabWindow,
+                        origTab,
+                        0,
+                        stateRef,
+                    );
+                }
             }
         }
     } catch (e) {

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -150,10 +150,17 @@ export function normalizeGoogleDocURL(url: string): string {
     const googleDocsRegex = /^https:\/\/docs\.google\.com\/(document|spreadsheets|presentation)\/d\/([a-zA-Z0-9-_]+)/;
     const match = url.match(googleDocsRegex);
     if (match) {
-      return `${match[0]}`; // Return the base URL without any parameters
+        return `${match[0]}`; // Return the base URL without any parameters
     }
     return url; // Return the original URL if it's not a Google Doc
 }
+
+export function isGoogleDocURL(url: string): boolean {
+    const googleDocsRegex = /^https:\/\/docs\.google\.com\/(document|spreadsheets|presentation)\/d\/([a-zA-Z0-9-_]+)/;
+    return googleDocsRegex.test(url);
+}
+
+// ... (rest of the utils.ts file remains the same)
 
 /**
  * chain a sequence of asynchronous actions

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -142,6 +142,20 @@ export function baseURL(url: string): string {
 }
 
 /**
+ * Normalize a Google Doc URL to the base URL without any parameters
+ * @param url 
+ * @returns 
+ */
+export function normalizeGoogleDocURL(url: string): string {
+    const googleDocsRegex = /^https:\/\/docs\.google\.com\/(document|spreadsheets|presentation)\/d\/([a-zA-Z0-9-_]+)/;
+    const match = url.match(googleDocsRegex);
+    if (match) {
+      return `${match[0]}`; // Return the base URL without any parameters
+    }
+    return url; // Return the original URL if it's not a Google Doc
+}
+
+/**
  * chain a sequence of asynchronous actions
  * TODO: Investigate if this can go away with latest iteration of
  * oneRef with awaitableUpdate


### PR DESCRIPTION
This pull request adds the ability to deduplicate Google docs, by ignoring URL parameters etc.
It also adds a preference to enable / disable this behavior.
This functionality required that deduplication of tabs is also enabled in preferences.