### PR TITLE
Remove the Google doc dedupe preference. It's not necessary and makes the preference pane complicated

### DIFF
--- a/src/ts/components/PreferencesModal.tsx
+++ b/src/ts/components/PreferencesModal.tsx
@@ -106,12 +106,6 @@ const PreferencesModal: React.FC<PreferencesModalProps> = ({
         updatePrefs({ dedupeTabs: !prefs.dedupeTabs });
     };
 
-    const handleDedupeGoogleDocsChange = (
-        e: React.ChangeEvent<HTMLInputElement>,
-    ) => {
-        updatePrefs({ dedupeGoogleDocs: !prefs.dedupeGoogleDocs });
-    };
-
     const handleRevertOnOpenChange = (
         e: React.ChangeEvent<HTMLInputElement>,
     ) => {
@@ -228,25 +222,6 @@ const PreferencesModal: React.FC<PreferencesModalProps> = ({
                                 />
                                 <label className={checkLabelStyle}>
                                     Automatically close duplicate tabs
-                                </label>
-                            </div>
-                            <div
-                                className={cx(
-                                    'checkbox',
-                                    rightCol,
-                                    prefsLabeledCheckbox,
-                                )}
-                            >
-                                <input
-                                    type="checkbox"
-                                    className={prefsCheckbox}
-                                    checked={prefs.dedupeGoogleDocs}
-                                    onChange={handleDedupeGoogleDocsChange}
-                                />
-                                <label className={checkLabelStyle}>
-                                    Automatically close duplicate Google Docs
-                                    (requires "Automatically close duplicate
-                                    tabs")
                                 </label>
                             </div>
                             <div

--- a/src/ts/preferences.ts
+++ b/src/ts/preferences.ts
@@ -17,7 +17,6 @@ export const USER_PREFS_KEY = 'UserPreferences';
 interface PreferencesProps {
     popoutOnStart: boolean;
     dedupeTabs: boolean;
-    dedupeGoogleDocs: boolean;
     revertOnOpen: boolean;
     theme: string;
     layout: string;
@@ -27,7 +26,6 @@ interface PreferencesProps {
 const defaultPreferencesProps: PreferencesProps = {
     popoutOnStart: false,
     dedupeTabs: false,
-    dedupeGoogleDocs: false,
     revertOnOpen: true,
     theme: 'light',
     layout: 'normal',
@@ -39,7 +37,6 @@ export class Preferences {
 
     popoutOnStart: boolean;
     dedupeTabs: boolean;
-    dedupeGoogleDocs: boolean;
     revertOnOpen: boolean;
     theme: string;
     layout: string;
@@ -48,7 +45,6 @@ export class Preferences {
     private constructor() {
         this.popoutOnStart = defaultPreferencesProps.popoutOnStart;
         this.dedupeTabs = defaultPreferencesProps.dedupeTabs;
-        this.dedupeGoogleDocs = defaultPreferencesProps.dedupeGoogleDocs;
         this.revertOnOpen = defaultPreferencesProps.revertOnOpen;
         this.theme = defaultPreferencesProps.theme;
         this.layout = defaultPreferencesProps.layout;

--- a/src/ts/tabManagerState.ts
+++ b/src/ts/tabManagerState.ts
@@ -454,9 +454,10 @@ export default class TabManagerState {
     }
 
     findURL(url: string): [TabWindow, TabItem][] {
+        const normalizedTargetUrl = utils.normalizeGoogleDocURL(url);
         if (
-            url === 'chrome://newtab/' ||
-            url.startsWith('chrome-extension://')
+            normalizedTargetUrl == 'chrome://newtab/' ||
+            normalizedTargetUrl.startsWith('chrome-extension://')
         ) {
             return [];
         }
@@ -466,7 +467,8 @@ export default class TabManagerState {
 
         for (const tabWindow of openWindows) {
             for (const tabItem of tabWindow.tabItems) {
-                if (tabItem.open && tabItem.url === url) {
+                const normalizedItemUrl = utils.normalizeGoogleDocURL(tabItem.url);
+                if (tabItem.open && normalizedItemUrl === normalizedTargetUrl) {
                     matches.push([tabWindow, tabItem]);
                 }
             }


### PR DESCRIPTION
Remove the Google doc dedupe preference. It's not necessary and makes the preference pane complicated.
Google doc deduplication is on if deduplication is on.
Also, fix the Google doc dedupe functionality. It got blown away in all the state work.